### PR TITLE
Patches errors for handling stand alone SELECT statements

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -5942,6 +5942,30 @@ func TestSingleStatementParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			`SELECT standalone`,
+			"SELECT * FROM users",
+			&ast.SQLStmt{
+				SelectStmt: &ast.SelectStmt{
+					SelectCore: []*ast.SelectCore{
+						&ast.SelectCore{
+							Select: token.New(1, 1, 0, 6, token.KeywordSelect, "SELECT"),
+							ResultColumn: []*ast.ResultColumn{
+								&ast.ResultColumn{
+									Asterisk: token.New(1, 8, 7, 1, token.BinaryOperator, "*"),
+								},
+							},
+							From: token.New(1, 10, 9, 4, token.KeywordFrom, "FROM"),
+							JoinClause: &ast.JoinClause{
+								TableOrSubquery: &ast.TableOrSubquery{
+									TableName: token.New(1, 15, 14, 5, token.Literal, "users"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, input := range inputs {
 		t.Run(input.Name, func(t *testing.T) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -5966,6 +5966,30 @@ func TestSingleStatementParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			`SELECT standalone with VALUES`,
+			"VALUES (expr)",
+			&ast.SQLStmt{
+				SelectStmt: &ast.SelectStmt{
+					SelectCore: []*ast.SelectCore{
+						&ast.SelectCore{
+							Values: token.New(1, 1, 0, 6, token.KeywordValues, "VALUES"),
+							ParenthesizedExpressions: []*ast.ParenthesizedExpressions{
+								&ast.ParenthesizedExpressions{
+									LeftParen: token.New(1, 8, 7, 1, token.Delimiter, "("),
+									Exprs: []*ast.Expr{
+										&ast.Expr{
+											LiteralValue: token.New(1, 9, 8, 4, token.Literal, "expr"),
+										},
+									},
+									RightParen: token.New(1, 13, 12, 1, token.Delimiter, ")"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, input := range inputs {
 		t.Run(input.Name, func(t *testing.T) {

--- a/internal/parser/simple_parser_rules.go
+++ b/internal/parser/simple_parser_rules.go
@@ -60,6 +60,8 @@ func (p *simpleParser) parseSQLStatement(r reporter) (stmt *ast.SQLStmt) {
 		stmt.CommitStmt = p.parseCommitStmt(r)
 	case token.KeywordRollback:
 		stmt.RollbackStmt = p.parseRollbackStmt(r)
+	case token.KeywordSelect:
+		stmt.SelectStmt = p.parseSelectStmt(r)
 	case token.KeywordVacuum:
 		stmt.VacuumStmt = p.parseVacuumStmt(r)
 	case token.KeywordWith:
@@ -1720,15 +1722,15 @@ func (p *simpleParser) parseWithClause(r reporter) (withClause *ast.WithClause) 
 		p.consumeToken()
 	}
 	for {
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Type() == token.Literal {
 			withClause.RecursiveCte = append(withClause.RecursiveCte, p.parseRecursiveCte(r))
 		}
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Value() == "," {
@@ -2174,8 +2176,8 @@ func (p *simpleParser) parseSelectCore(r reporter) (stmt *ast.SelectCore) {
 			}
 		}
 
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Type() == token.KeywordFrom {
@@ -2198,8 +2200,8 @@ func (p *simpleParser) parseSelectCore(r reporter) (stmt *ast.SelectCore) {
 			}
 		}
 
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Type() == token.KeywordWhere {
@@ -2208,8 +2210,8 @@ func (p *simpleParser) parseSelectCore(r reporter) (stmt *ast.SelectCore) {
 			stmt.Expr1 = p.parseExpression(r)
 		}
 
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Type() == token.KeywordGroup {
@@ -2247,8 +2249,8 @@ func (p *simpleParser) parseSelectCore(r reporter) (stmt *ast.SelectCore) {
 			}
 		}
 
-		next, ok = p.lookahead(r)
-		if !ok {
+		next, ok = p.optionalLookahead(r)
+		if !ok || next.Type() == token.EOF || next.Type() == token.StatementSeparator {
 			return
 		}
 		if next.Type() == token.KeywordWindow {


### PR DESCRIPTION
`SELECT * FROM users` and statements of the sort weren't being parsed due to `lookahead`s being used instead of `optionalLookahead`s.
This PR fixes the errors and parses statements of the sort given above.