### PR TITLE
Add underscore and dash to literal

### DIFF
--- a/internal/parser/scanner/rule_based_scanner_test.go
+++ b/internal/parser/scanner/rule_based_scanner_test.go
@@ -249,6 +249,42 @@ func TestRuleBasedScanner(t *testing.T) {
 				token.New(1, 13, 12, 0, token.EOF, ""),
 			},
 		},
+		{
+			"underscore in single unquoted token",
+			"alpha_beta",
+			ruleset.Default,
+			[]token.Token{
+				token.New(1, 1, 0, 10, token.Literal, "alpha_beta"),
+				token.New(1, 11, 10, 0, token.EOF, ""),
+			},
+		},
+		{
+			"underscore in single quoted token",
+			"\"alpha_beta\"",
+			ruleset.Default,
+			[]token.Token{
+				token.New(1, 1, 0, 12, token.Literal, "\"alpha_beta\""),
+				token.New(1, 13, 12, 0, token.EOF, ""),
+			},
+		},
+		{
+			"dash in single unquoted token",
+			"alpha-beta",
+			ruleset.Default,
+			[]token.Token{
+				token.New(1, 1, 0, 10, token.Literal, "alpha-beta"),
+				token.New(1, 11, 10, 0, token.EOF, ""),
+			},
+		},
+		{
+			"dash in single quoted token",
+			"\"alpha-beta\"",
+			ruleset.Default,
+			[]token.Token{
+				token.New(1, 1, 0, 12, token.Literal, "\"alpha-beta\""),
+				token.New(1, 13, 12, 0, token.EOF, ""),
+			},
+		},
 	}
 	for _, input := range inputs {
 		t.Run("ruleset=default/"+input.name, _TestRuleBasedScannerWithRuleset(input.query, input.ruleset, input.want))

--- a/internal/parser/scanner/ruleset/ruleset_default.go
+++ b/internal/parser/scanner/ruleset/ruleset_default.go
@@ -33,6 +33,7 @@ var (
 		matcher.New("upper", unicode.Upper),
 		matcher.New("lower", unicode.Lower),
 		matcher.New("title", unicode.Title),
+		matcher.String("-_"),
 		defaultNumber,
 	)
 	defaultNumericLiteral = matcher.Merge(


### PR DESCRIPTION
Added underscore (`_`) and dash (`-`) to literal.
Literals can now contain these characters.

Closes #147

## Definition of done
- [ ] Code correctness
- [ ] Documentation
- [ ] Test cases
