### PR TITLE
compiler: add support for DELETE statements

### DIFF
--- a/internal/compiler/command/command.go
+++ b/internal/compiler/command/command.go
@@ -110,6 +110,17 @@ type (
 		Input List
 	}
 
+	// Delete instructs the instructor to delete all datasets from a table, that
+	// match the filter.
+	Delete struct {
+		// Table is the table to delete datasets from.
+		Table Table
+		// Filter is an expression that a dataset has to match in order to be
+		// deleted. This must not be nil. If all datasets from the table have to
+		// be deleted, the filter will be a constant true expression.
+		Filter Expr
+	}
+
 	// Column represents a database table column.
 	Column struct {
 		// Table is the table name that this column belongs to. May be empty, as
@@ -214,6 +225,10 @@ func (p Project) String() string {
 		colStrs[i] = col.String()
 	}
 	return fmt.Sprintf("Project[cols=%v](%v)", strings.Join(colStrs, ","), p.Input)
+}
+
+func (d Delete) String() string {
+	return fmt.Sprintf("Delete[filter=%v](%v)", d.Filter, d.Table)
 }
 
 func (c Column) String() string {

--- a/internal/compiler/command/expr.go
+++ b/internal/compiler/command/expr.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -21,8 +22,10 @@ type (
 		Value string
 	}
 
-	// BooleanExpr is a simple expression that represents a boolean value.
-	BooleanExpr struct {
+	// ConstantBooleanExpr is a simple expression that represents a boolean
+	// value. It is rarely emitted by the compiler and rather used by
+	// optimizations.
+	ConstantBooleanExpr struct {
 		// Value is the simple bool value of this expression.
 		Value bool
 	}
@@ -87,15 +90,20 @@ type (
 	}
 )
 
-func (LiteralExpr) _expr()  {}
-func (EqualityExpr) _expr() {}
-func (RangeExpr) _expr()    {}
-func (UnaryExpr) _expr()    {}
-func (BinaryExpr) _expr()   {}
-func (FunctionExpr) _expr() {}
+func (LiteralExpr) _expr()         {}
+func (ConstantBooleanExpr) _expr() {}
+func (EqualityExpr) _expr()        {}
+func (RangeExpr) _expr()           {}
+func (UnaryExpr) _expr()           {}
+func (BinaryExpr) _expr()          {}
+func (FunctionExpr) _expr()        {}
 
 func (l LiteralExpr) String() string {
 	return l.Value
+}
+
+func (b ConstantBooleanExpr) String() string {
+	return strconv.FormatBool(b.Value)
 }
 
 func (e EqualityExpr) String() string {


### PR DESCRIPTION
Add support for `DELETE` statements without `WITH` clauses.

Closes #137

## Definition of done
- [ ] Code correctness
- [ ] Documentation
- [ ] Test cases
