### PR TITLE
Run tests without race detector by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ all: lint test build ## test -> lint -> build
 
 .PHONY: test
 test: ## Runs the unit test suite
+	go test ./...
+
+.PHONY: race
+race: ## Runs the unit test suite with the race detector enabled (slow, ~45sec)
 	go test -race ./...
 
 .PHONY: lint


### PR DESCRIPTION
I noticed that when running the tests with the default test command, the run would take around 45 seconds to finish. Initially I thought this was due to the fuzzing not using a build tag, however this wasn't the case.

I noticed that when run with the race detector, the `parser_test.go` file in particular takes a rather absurd amount of time. In order to have a slightly tighter feedback loop on the main test command, I've removed the race detector and put it in a separate target.

## Definition of done
- [ ] Code correctness
- [ ] Documentation
- [ ] Test cases
