### PR TITLE
engine: fix not casting expression to string in projection

### DIFF
--- a/internal/engine/evaluate.go
+++ b/internal/engine/evaluate.go
@@ -59,6 +59,12 @@ func (e Engine) evaluateProjection(ctx ExecutionContext, proj command.Project) (
 		var colName string
 		if colNameExpr.Is(types.String) {
 			colName = colNameExpr.(types.StringValue).Value
+		} else {
+			casted, err := types.String.Cast(colNameExpr)
+			if err != nil {
+				return Table{}, fmt.Errorf("cannot cast %v to %v: %w", colNameExpr.Type(), types.String, err)
+			}
+			colName = casted.(types.StringValue).Value
 		}
 		if col.Table != "" {
 			colName = col.Table + "." + colName


### PR DESCRIPTION
Projection did not attempt to cast the col name expression to a string, in case it wasn't a string.
This PR fixes that issue.

Closes nothing.

## Definition of done
- [ ] Code correctness
- [ ] Documentation
- [ ] Test cases
