### PR TITLE
engine: add support for alias in projection

### DIFF
--- a/internal/engine/error.go
+++ b/internal/engine/error.go
@@ -41,3 +41,9 @@ func ErrUncomparable(t types.Type) Error {
 func ErrUnimplemented(what interface{}) Error {
 	return Error(fmt.Sprintf("'%v' is not implemented", what))
 }
+
+// ErrNoSuchColumn returns an error indicating that a requested column is not
+// contained in the current result table.
+func ErrNoSuchColumn(name string) Error {
+	return Error(fmt.Sprintf("no column with name or alias '%s'", name))
+}

--- a/internal/engine/table.go
+++ b/internal/engine/table.go
@@ -54,6 +54,17 @@ func (t Table) RemoveColumnByQualifiedName(qualifiedName string) Table {
 	return t
 }
 
+// HasColumn inspects the table's columns and determines whether the table has
+// any column, that has the given name as qualified name OR as alias.
+func (t Table) HasColumn(qualifiedNameOrAlias string) bool {
+	for _, col := range t.Cols {
+		if col.QualifiedName == qualifiedNameOrAlias || col.Alias == qualifiedNameOrAlias {
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveColumn works on a copy of the table, and removes the column with the
 // given index from the copy. After removal, the copy is returned.
 func (t Table) RemoveColumn(index int) Table {


### PR DESCRIPTION
Added support for aliases in projection. Table columns keep their original qualified name, and the alias is set. That way, a column can be referenced by either the alias or its qualified name.
This is the same behavior that SQLite has.

Closes #193

## Definition of done
- [ ] Code correctness
- [ ] Documentation
- [ ] Test cases
