### PR TITLE
engine: correct current page implementation

### DIFF
--- a/internal/engine/storage/page/page.go
+++ b/internal/engine/storage/page/page.go
@@ -58,8 +58,14 @@ func Load(data []byte) (*Page, error) {
 	return load(data)
 }
 
+// DecodeID decodes a page ID from the given bytes. The ID is stored in the
+// first 4 bytes, encoded big endian unsigned.
+func DecodeID(data []byte) ID {
+	return byteOrder.Uint32(data[idOffset:])
+}
+
 // ID returns the ID of this page. This value must be constant.
-func (p *Page) ID() ID { return byteOrder.Uint32(p.data[idOffset:]) }
+func (p *Page) ID() ID { return DecodeID(p.data) }
 
 // CellCount returns the amount of stored cells in this page. This value is NOT
 // constant.

--- a/internal/engine/storage/page_manager.go
+++ b/internal/engine/storage/page_manager.go
@@ -12,8 +12,9 @@ import (
 // writing pages to secondary storage. It also can allocate new pages, which
 // will immediately be written to secondary storage.
 type PageManager struct {
-	file      afero.File
-	largestID page.ID
+	file        afero.File
+	largestID   page.ID
+	pageOffsets map[page.ID]int64
 }
 
 // NewPageManager creates a new page manager over the given file. It is assumed,
@@ -25,8 +26,16 @@ func NewPageManager(file afero.File) (*PageManager, error) {
 	}
 
 	mgr := &PageManager{
-		file:      file,
-		largestID: uint32(stat.Size() / page.Size),
+		file:        file,
+		pageOffsets: make(map[page.ID]int64),
+	}
+	if err := mgr.loadPageIDs(stat.Size()); err != nil {
+		return nil, fmt.Errorf("load page ids: %w", err)
+	}
+	for k := range mgr.pageOffsets {
+		if k > mgr.largestID {
+			mgr.largestID = k
+		}
 	}
 
 	return mgr, nil
@@ -35,8 +44,13 @@ func NewPageManager(file afero.File) (*PageManager, error) {
 // ReadPage returns the page with the given ID, or an error if reading is
 // impossible.
 func (m *PageManager) ReadPage(id page.ID) (*page.Page, error) {
+	offset, ok := m.pageOffsets[id]
+	if !ok {
+		return nil, fmt.Errorf("no offset for page %v", id)
+	}
+
 	data := make([]byte, page.Size)
-	_, err := m.file.ReadAt(data, int64(id)*page.Size)
+	_, err := m.file.ReadAt(data, offset)
 	if err != nil {
 		return nil, fmt.Errorf("read at: %w", err)
 	}
@@ -50,8 +64,20 @@ func (m *PageManager) ReadPage(id page.ID) (*page.Page, error) {
 // WritePage will write the given page into secondary storage. It is guaranteed,
 // that after this call returns, the page is present on disk.
 func (m *PageManager) WritePage(p *page.Page) error {
+	offset, ok := m.pageOffsets[p.ID()]
+	// if there's no offset for the page present yet, append it at the end of
+	// the page
+	if !ok {
+		info, err := m.file.Stat()
+		if err != nil {
+			return fmt.Errorf("stat: %w", err)
+		}
+		offset = info.Size()
+		m.pageOffsets[p.ID()] = offset
+	}
+
 	data := p.RawData()
-	_, err := m.file.WriteAt(data, int64(p.ID())*page.Size)
+	_, err := m.file.WriteAt(data, offset)
 	if err != nil {
 		return fmt.Errorf("write at: %w", err)
 	}
@@ -81,5 +107,22 @@ func (m *PageManager) Close() error {
 		return fmt.Errorf("sync: %w", err)
 	}
 	_ = m.file.Close()
+	return nil
+}
+
+// loadPageIDs initializes the page manager's pageOffsets.
+func (m *PageManager) loadPageIDs(fileSize int64) error {
+	idBuf := make([]byte, 4)
+	for i := int64(0); i < fileSize; i += page.Size {
+		_, err := m.file.ReadAt(idBuf, i)
+		if err != nil {
+			return fmt.Errorf("read at %v: %w", i, err)
+		}
+		id := page.DecodeID(idBuf)
+		if _, ok := m.pageOffsets[id]; ok {
+			return fmt.Errorf("duplicate page id %v", id)
+		}
+		m.pageOffsets[id] = i
+	}
 	return nil
 }

--- a/internal/engine/storage/page_manager_test.go
+++ b/internal/engine/storage/page_manager_test.go
@@ -1,0 +1,87 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
+	"github.com/tomarrell/lbadd/internal/engine/storage/page"
+)
+
+type PageManagerSuite struct {
+	suite.Suite
+
+	file afero.File
+}
+
+func (suite *PageManagerSuite) SetupTest() {
+	fs := afero.NewMemMapFs()
+	// empty file
+	file, err := fs.Create("mydbfile")
+	suite.NoError(err)
+
+	setupMgr, err := NewPageManager(file)
+	suite.NoError(err)
+
+	// allocate three pages with id 0 through 2
+	_, err = setupMgr.AllocateNew()
+	suite.NoError(err)
+	_, err = setupMgr.AllocateNew()
+	suite.NoError(err)
+	_, err = setupMgr.AllocateNew()
+	suite.NoError(err)
+
+	// modify id of page with id 1
+	_, err = file.WriteAt([]byte{0x00, 0x00, 0x00, 0x03}, page.Size)
+	suite.NoError(err)
+
+	suite.file = file
+}
+
+func (suite *PageManagerSuite) TestPageManager_loadPageIDs() {
+	testMgr, err := NewPageManager(suite.file)
+	suite.NoError(err)
+
+	// test the page manager's loaded page offsets
+	suite.EqualValues(0*page.Size, testMgr.pageOffsets[0])
+	suite.EqualValues(1*page.Size, testMgr.pageOffsets[3])
+	suite.EqualValues(2*page.Size, testMgr.pageOffsets[2])
+	suite.Len(testMgr.pageOffsets, 3)
+
+	var p *page.Page
+	p, err = testMgr.ReadPage(0)
+	suite.NoError(err)
+	suite.EqualValues(0, p.ID())
+	p, err = testMgr.ReadPage(2)
+	suite.NoError(err)
+	suite.EqualValues(2, p.ID())
+	p, err = testMgr.ReadPage(3)
+	suite.NoError(err)
+	suite.EqualValues(3, p.ID())
+}
+
+func (suite *PageManagerSuite) TestPageManager_AllocateNew() {
+	fs := afero.NewMemMapFs()
+	// empty file
+	file, err := fs.Create("mydbfile")
+	suite.NoError(err)
+
+	mgr, err := NewPageManager(file)
+	suite.NoError(err)
+	defer func() { _ = mgr.Close() }()
+
+	var p []*page.Page
+	for i := 0; i < 5; i++ {
+		newPage, err := mgr.AllocateNew()
+		suite.NoError(err)
+		p = append(p, newPage)
+	}
+
+	for i := 0; i < len(p); i++ {
+		suite.EqualValues(i, p[i].ID())
+	}
+}
+
+func TestPageManagerSuite(t *testing.T) {
+	suite.Run(t, new(PageManagerSuite))
+}


### PR DESCRIPTION
The current page implementation and usage is incorrect.
The timing of page defragmentation and the use of overflow pages is factually incorrect, and won't work as intended.
This PR fixes the faulty implementation.

_Closes nothing_